### PR TITLE
Cloudflare Pages へのデプロイ対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@types/react-dom": "^18.0.6",
         "@typescript-eslint/eslint-plugin": "^5.40.1",
-        "dotenv-webpack": "^8.0.1",
         "eslint": "^8.26.0",
         "eslint-config-standard-with-typescript": "^23.0.0",
         "eslint-plugin-import": "^2.26.0",
@@ -1927,39 +1926,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/dotenv-defaults": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
-      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "^8.2.0"
-      }
-    },
-    "node_modules/dotenv-webpack": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
-      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
-      "dev": true,
-      "dependencies": {
-        "dotenv-defaults": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "webpack": "^4 || ^5"
       }
     },
     "node_modules/ee-first": {
@@ -7865,30 +7831,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true
-    },
-    "dotenv-defaults": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
-      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
-      "dev": true,
-      "requires": {
-        "dotenv": "^8.2.0"
-      }
-    },
-    "dotenv-webpack": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
-      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
-      "dev": true,
-      "requires": {
-        "dotenv-defaults": "^2.0.2"
       }
     },
     "ee-first": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack --mode=production --node-env=production",
+    "build": "npm run copy && npm run build:prod",
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production --node-env=production",
     "watch": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@types/react-dom": "^18.0.6",
     "@typescript-eslint/eslint-plugin": "^5.40.1",
-    "dotenv-webpack": "^8.0.1",
     "eslint": "^8.26.0",
     "eslint-config-standard-with-typescript": "^23.0.0",
     "eslint-plugin-import": "^2.26.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require("webpack");
 
 const isProduction = process.env.NODE_ENV == "production";
-const Dotenv = require("dotenv-webpack");
 
 const config = {
   entry: "./src/index.tsx",
@@ -19,7 +19,9 @@ const config = {
     new HtmlWebpackPlugin({
       template: "index.html",
     }),
-    new Dotenv(),
+    new webpack.DefinePlugin({
+      "process.env.ARCGIS_APIKEY": JSON.stringify(process.env.ARCGIS_APIKEY),
+    }),
   ],
   module: {
     rules: [


### PR DESCRIPTION
Cloudflare Pages でのデプロイに対応するための調整
- デプロイコマンドの修正
- 環境変数の読み込み方法の変更(`process.env` ではなく webpack 5 の `DefinePlugin`)