### PR TITLE
Implemented character encoding option for CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@arcgis/core": "^4.23.7",
         "@esri/calcite-components-react": "^0.32.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "wanco": "^0.1.1"
       },
       "devDependencies": {
         "@types/react-dom": "^18.0.6",
@@ -6113,6 +6114,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/wanco": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wanco/-/wanco-0.1.1.tgz",
+      "integrity": "sha512-0obXBo06lvmumyN41WFfb/O1zsjkaBoP3obHvSE5/O89det5HnY7nYz+D+25Y+Oa2bzJuf8re1eOQbvxQDSIwQ=="
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -11118,6 +11124,11 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
+    },
+    "wanco": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wanco/-/wanco-0.1.1.tgz",
+      "integrity": "sha512-0obXBo06lvmumyN41WFfb/O1zsjkaBoP3obHvSE5/O89det5HnY7nYz+D+25Y+Oa2bzJuf8re1eOQbvxQDSIwQ=="
     },
     "watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@arcgis/core": "^4.23.7",
     "@esri/calcite-components-react": "^0.32.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "wanco": "^0.1.1"
   },
   "engines": {
     "node": ">= 16",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,15 @@ export const App = () => {
   return (
     <>
       <MenuContext.Provider
-        value={{ isSetAttr: isSetAttributes, setIsSetAttr: setIsSetAttributes }}
+        value={{
+          isSetAttr: isSetAttributes,
+          setIsSetAttr: setIsSetAttributes,
+          csvExportSetting: {
+            encoding: "utf-8",
+            lineBreak: "\n"
+          },
+          setCsvExportEncoding: (_) => {},
+        }}
       >
         <Menu />
         <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ export const App = () => {
           setIsSetAttr: setIsSetAttributes,
           csvExportSetting: {
             encoding: "utf-8",
-            lineBreak: "\n"
+            lineBreak: "\n",
           },
           setCsvExportEncoding: (_) => {},
         }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,13 @@ import { mapView } from "./mapView";
 import { MenuContext } from "./contexts";
 import { createMarker } from "./drawGraphic";
 import { layerStore } from "./layers";
+import { encoding_t } from "./contexts";
 
 export const App = () => {
   const [isSetAttributes, setIsSetAttributes] = useState(false);
+  const [csvExportEncoding, setCsvExportEncoding] = useState(
+    "utf-8" as encoding_t
+  );
 
   useEffect(() => {
     mapView.set("container", "viewDiv");
@@ -26,10 +30,10 @@ export const App = () => {
           isSetAttr: isSetAttributes,
           setIsSetAttr: setIsSetAttributes,
           csvExportSetting: {
-            encoding: "utf-8",
+            encoding: csvExportEncoding,
             lineBreak: "\n",
           },
-          setCsvExportEncoding: (_) => {},
+          setCsvExportEncoding: setCsvExportEncoding,
         }}
       >
         <Menu />

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -1,7 +1,7 @@
 import { downloadGraphicsAsCSV } from "../../download/graphics";
 import { handleSelection } from "../../loadCSV";
 import { useContext } from "react";
-import { MenuContext } from "../../contexts";
+import { MenuContext, csvEncodingSetting_t } from "../../contexts";
 import {
   CalciteBlock,
   CalciteIcon,
@@ -63,7 +63,15 @@ export const Menu = () => {
               }}
             />
           </CalciteLabel>
-          <CalciteDropdown>
+          <CalciteDropdown
+            onCalciteDropdownSelect={(e) => {
+              // TODO: 実装の検討 (1/2)
+              {/* @ts-ignore */}
+              const encoding = e.target.selectedItems[0].attributes[0]
+                .nodeValue as csvEncodingSetting_t;
+              context.setCsvExportEncoding(encoding);
+            }}
+          >
             <CalciteButton
               slot="dropdown-trigger"
               style={{ margin: marginEachComponents }}
@@ -74,9 +82,21 @@ export const Menu = () => {
               selection-mode="single"
               group-title="文字エンコーディング"
             >
-              <CalciteDropdownItem selected>UTF-8</CalciteDropdownItem>
-              <CalciteDropdownItem>EUC-JP</CalciteDropdownItem>
-              <CalciteDropdownItem>Shift_JIS</CalciteDropdownItem>
+              {/* 
+              TODO: 実装の検討 (2/2)
+              CalciteDropdownItem に value に当たる属性が見つからず、選択時に textContent などから取得する方法しか浮かばなかった。
+              型情報を保持するためにReactコンポーネントの属性情報として保持するため、
+              defaultValueを利用するが、正しい利用方法か不明
+              */}
+              <CalciteDropdownItem defaultValue={"UTF-8"} selected>
+                UTF-8
+              </CalciteDropdownItem>
+              <CalciteDropdownItem defaultValue={"EUC-JP"}>
+                EUC-JP
+              </CalciteDropdownItem>
+              <CalciteDropdownItem defaultValue={"Shift_JIS"}>
+                Shift_JIS
+              </CalciteDropdownItem>
             </CalciteDropdownGroup>
           </CalciteDropdown>
         </CalcitePanel>

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -9,6 +9,9 @@ import {
   CalciteLabel,
   CalciteButton,
   CalcitePanel,
+  CalciteDropdown,
+  CalciteDropdownGroup,
+  CalciteDropdownItem,
 } from "@esri/calcite-components-react";
 
 export const Menu = () => {
@@ -27,7 +30,7 @@ export const Menu = () => {
         }}
       >
         <CalciteIcon scale="m" slot="icon" icon="hamburger"></CalciteIcon>
-        <CalcitePanel id="menu">
+        <CalcitePanel id="menu" style={{ overflow: "visible" }}>
           {/* CalciteInputがfileのmultipleをサポートしていないため素のinput */}
           <div style={{ margin: marginEachComponents }}>
             <label htmlFor="fileselect-csv">CSVファイルのインポート</label>
@@ -46,6 +49,7 @@ export const Menu = () => {
           >
             CSVファイルのエクスポート
           </CalciteButton>
+
           <CalciteLabel
             layout="inline"
             style={{ margin: marginEachComponents }}
@@ -59,6 +63,22 @@ export const Menu = () => {
               }}
             />
           </CalciteLabel>
+          <CalciteDropdown>
+            <CalciteButton
+              slot="dropdown-trigger"
+              style={{ margin: marginEachComponents }}
+            >
+              CSVエクスポート設定
+            </CalciteButton>
+            <CalciteDropdownGroup
+              selection-mode="single"
+              group-title="文字エンコーディング"
+            >
+              <CalciteDropdownItem selected>UTF-8</CalciteDropdownItem>
+              <CalciteDropdownItem>EUC-JP</CalciteDropdownItem>
+              <CalciteDropdownItem>Shift_JIS</CalciteDropdownItem>
+            </CalciteDropdownGroup>
+          </CalciteDropdown>
         </CalcitePanel>
       </CalciteBlock>
     </>

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -46,7 +46,7 @@ export const Menu = () => {
           <CalciteButton
             style={{ margin: marginEachComponents }}
             id="dl-graphics"
-            onClick={() => downloadGraphicsAsCSV()}
+            onClick={() => downloadGraphicsAsCSV(context.csvExportSetting)}
           >
             CSVファイルのエクスポート
           </CalciteButton>

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -1,7 +1,7 @@
 import { downloadGraphicsAsCSV } from "../../download/graphics";
 import { handleSelection } from "../../loadCSV";
 import { useContext } from "react";
-import { MenuContext, csvEncodingSetting_t } from "../../contexts";
+import { MenuContext, encoding_t } from "../../contexts";
 import {
   CalciteBlock,
   CalciteIcon,
@@ -67,9 +67,8 @@ export const Menu = () => {
           <CalciteDropdown
             onCalciteDropdownSelect={(e) => {
               // TODO: 実装の検討 (1/2)
-              {/* @ts-ignore */}
               const encoding = e.target.selectedItems[0].attributes[0]
-                .nodeValue as csvEncodingSetting_t;
+                .nodeValue as encoding_t;
               context.setCsvExportEncoding(encoding);
             }}
           >
@@ -91,12 +90,13 @@ export const Menu = () => {
               defaultValueを利用するが、正しい利用方法か不明
               */
                 supportedEncodings.map((encoding) => {
-                  const selected = context.csvExportSetting.encoding === encoding.value
+                  const selected =
+                    context.csvExportSetting.encoding === encoding.value;
                   return (
                     <CalciteDropdownItem
                       defaultValue={encoding.value}
                       key={encoding.value}
-                      selected={ selected }
+                      selected={selected}
                     >
                       {encoding.displayName}
                     </CalciteDropdownItem>

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -13,6 +13,7 @@ import {
   CalciteDropdownGroup,
   CalciteDropdownItem,
 } from "@esri/calcite-components-react";
+import { supportedEncodings } from "../../download/settings";
 
 export const Menu = () => {
   const context = useContext(MenuContext);
@@ -82,21 +83,26 @@ export const Menu = () => {
               selection-mode="single"
               group-title="文字エンコーディング"
             >
-              {/* 
+              {
+                /* 
               TODO: 実装の検討 (2/2)
               CalciteDropdownItem に value に当たる属性が見つからず、選択時に textContent などから取得する方法しか浮かばなかった。
               型情報を保持するためにReactコンポーネントの属性情報として保持するため、
               defaultValueを利用するが、正しい利用方法か不明
-              */}
-              <CalciteDropdownItem defaultValue={"UTF-8"} selected>
-                UTF-8
-              </CalciteDropdownItem>
-              <CalciteDropdownItem defaultValue={"EUC-JP"}>
-                EUC-JP
-              </CalciteDropdownItem>
-              <CalciteDropdownItem defaultValue={"Shift_JIS"}>
-                Shift_JIS
-              </CalciteDropdownItem>
+              */
+                supportedEncodings.map((encoding) => {
+                  const selected = context.csvExportSetting.encoding === encoding.value
+                  return (
+                    <CalciteDropdownItem
+                      defaultValue={encoding.value}
+                      key={encoding.value}
+                      selected={ selected }
+                    >
+                      {encoding.displayName}
+                    </CalciteDropdownItem>
+                  );
+                })
+              }
             </CalciteDropdownGroup>
           </CalciteDropdown>
         </CalcitePanel>

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -5,11 +5,15 @@ type lineBreak_t = "\n" | "\r\n";
 export type csvEncodingSetting_t = {
   encoding: encoding_t;
 };
+export type downloadOption = {
+  encoding: encoding_t;
+  lineBreak: lineBreak_t;
+};
 
 type MenuContext = {
   isSetAttr: boolean;
   setIsSetAttr: (isSet: boolean) => void;
-  csvExportSetting: { encoding: encoding_t; lineBreak: lineBreak_t };
+  csvExportSetting: downloadOption;
   setCsvExportEncoding: (setting: csvEncodingSetting_t) => void;
 };
 

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -2,9 +2,7 @@ import { createContext } from "react";
 
 export type encoding_t = "utf-8" | "euc-jp" | "shift_jis";
 type lineBreak_t = "\n" | "\r\n";
-export type csvEncodingSetting_t = {
-  encoding: encoding_t;
-};
+
 export type downloadOption = {
   encoding: encoding_t;
   lineBreak: lineBreak_t;
@@ -14,7 +12,7 @@ type MenuContext = {
   isSetAttr: boolean;
   setIsSetAttr: (isSet: boolean) => void;
   csvExportSetting: downloadOption;
-  setCsvExportEncoding: (setting: csvEncodingSetting_t) => void;
+  setCsvExportEncoding: (setting: encoding_t) => void;
 };
 
 export const defaultContext: MenuContext = {
@@ -22,7 +20,7 @@ export const defaultContext: MenuContext = {
   setIsSetAttr: (() => {}) as React.Dispatch<React.SetStateAction<boolean>>,
   csvExportSetting: { encoding: "utf-8", lineBreak: "\n" },
   setCsvExportEncoding: (() => {}) as React.Dispatch<
-    React.SetStateAction<csvEncodingSetting_t>
+    React.SetStateAction<encoding_t>
   >,
 };
 

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,13 +1,25 @@
 import { createContext } from "react";
 
+type encoding_t = "utf-8" | "euc-jp" | "shift_jis";
+type lineBreak_t = "\n" | "\r\n";
+export type csvEncodingSetting_t = {
+  encoding: encoding_t;
+};
+
 type MenuContext = {
   isSetAttr: boolean;
   setIsSetAttr: (isSet: boolean) => void;
+  csvExportSetting: { encoding: encoding_t; lineBreak: lineBreak_t };
+  setCsvExportEncoding: (setting: csvEncodingSetting_t) => void;
 };
 
 export const defaultContext: MenuContext = {
   isSetAttr: false,
   setIsSetAttr: (() => {}) as React.Dispatch<React.SetStateAction<boolean>>,
+  csvExportSetting: { encoding: "utf-8", lineBreak: "\n" },
+  setCsvExportEncoding: (() => {}) as React.Dispatch<
+    React.SetStateAction<csvEncodingSetting_t>
+  >,
 };
 
 export const MenuContext = createContext<MenuContext>(defaultContext);

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-type encoding_t = "utf-8" | "euc-jp" | "shift_jis";
+export type encoding_t = "utf-8" | "euc-jp" | "shift_jis";
 type lineBreak_t = "\n" | "\r\n";
 export type csvEncodingSetting_t = {
   encoding: encoding_t;

--- a/src/download/graphics.ts
+++ b/src/download/graphics.ts
@@ -1,36 +1,32 @@
 import Graphic from "@arcgis/core/Graphic";
 import { layerStore } from "../layers";
 import { downloadAsCSV } from "./handleBlob";
-import { downloadOption } from "../contexts"
+import { downloadOption } from "../contexts";
+import init, { encode } from "wanco";
 
 // TODO: 型をしっかりつける
 type graphicItem = Graphic & {
   geometry: { latitude: number; longitude: number };
 };
 
-const defaultOption: downloadOption = {
-  encoding: "utf-8",
-  lineBreak: "\n",
-} as const;
-
-// TODO: Shift_JIS対応
-// TextEncoderでは難しそうだった
-export const downloadGraphicsAsCSV = (
-  option: downloadOption = defaultOption
-): void => {
-  const header = ["名前", "緯度", "経度"].join(",");
-  // @ts-expect-error
-  const items = layerStore.graphicsLayer.graphics.items as graphicItem[];
-  const content = items
-    .map((item) =>
-      [
-        item.attributes.name,
-        item.geometry.latitude,
-        item.geometry.longitude,
-      ].join(",")
-    )
-    .join(option.lineBreak);
-  // Ensure to ends with blank line.
-  const csvContent = [header, content, ""].join(option.lineBreak);
-  downloadAsCSV(csvContent);
+export const downloadGraphicsAsCSV = (option: downloadOption): void => {
+  init().then(() => {
+    const header = ["名前", "緯度", "経度"].join(",");
+    // @ts-expect-error
+    const items = layerStore.graphicsLayer.graphics.items as graphicItem[];
+    const content = items
+      .map((item) =>
+        [
+          item.attributes.name,
+          item.geometry.latitude,
+          item.geometry.longitude,
+        ].join(",")
+      )
+      .join(option.lineBreak);
+    // Ensure to ends with blank line.
+    const csvContent = [header, content, ""].join(option.lineBreak);
+    const encoded = encode(csvContent, option.encoding);
+    const saveContent = new Uint8Array(encoded.bytes);
+    downloadAsCSV(saveContent);
+  });
 };

--- a/src/download/graphics.ts
+++ b/src/download/graphics.ts
@@ -1,11 +1,7 @@
 import Graphic from "@arcgis/core/Graphic";
 import { layerStore } from "../layers";
 import { downloadAsCSV } from "./handleBlob";
-
-type downloadOption = {
-  encoding: "utf-8";
-  lineBreak: "\n" | "\r\n";
-};
+import { downloadOption } from "../contexts"
 
 // TODO: 型をしっかりつける
 type graphicItem = Graphic & {

--- a/src/download/handleBlob.ts
+++ b/src/download/handleBlob.ts
@@ -1,4 +1,4 @@
-export const downloadAsCSV = (content: string): void => {
+export const downloadAsCSV = (content: Uint8Array): void => {
   const blob = new Blob([content], { type: "text/csv" });
   const anchor = document.createElement("a");
   anchor.download = "points.csv";

--- a/src/download/settings.ts
+++ b/src/download/settings.ts
@@ -1,0 +1,9 @@
+import { encoding_t } from "../contexts";
+export const supportedEncodings: Array<{
+  displayName: string;
+  value: encoding_t;
+}> = [
+  { displayName: "UTF-8", value: "utf-8" },
+  { displayName: "EUC-JP", value: "euc-jp" },
+  { displayName: "Shift_JIS", value: "shift_jis" },
+];


### PR DESCRIPTION
CSV ファイルの出力時に文字エンコーディングを指定できるようにした。
現状は

- UTF-8 (初期値)
- EUC-JP
- Shift_JIS

の3つのみ対応

エンコーディング形式を増やす場合、[wanco](https://github.com/ogumaru/wanco)での対応が必要。